### PR TITLE
fsa-bcst-uhd-router-svc to 1.0.3

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -9,8 +9,8 @@ dependencies:
   version: 2.3.112
 - name: fsa-bcst-uhd-router-svc
   repository: https://artifactory.cluster.foxsports-gitops-prod.com.au/artifactory/helm
-  version: 1.0.2
-- name: ha-proxy
-  alias: fsa-bcst-uhd-router-proxy
+  version: 1.0.3
+- alias: fsa-bcst-uhd-router-proxy
+  name: ha-proxy
   repository: https://artifactory.cluster.foxsports-gitops-prod.com.au/artifactory/helm
   version: 0.0.2


### PR DESCRIPTION
Promote fsa-bcst-uhd-router-svc to version 1.0.3